### PR TITLE
DKG Safer transition of phases

### DIFF
--- a/share/dkg/protocol.go
+++ b/share/dkg/protocol.go
@@ -156,6 +156,7 @@ func (p *Protocol) startFast() {
 	var justifs = newSet()
 	var newN = len(p.dkg.c.NewNodes)
 	var oldN = len(p.dkg.c.OldNodes)
+	// we keep the phase in sync with the dkg phase
 	state := func() Phase {
 		return p.dkg.state
 	}

--- a/share/dkg/protocol.go
+++ b/share/dkg/protocol.go
@@ -157,14 +157,14 @@ func (p *Protocol) startFast() {
 	var newN = len(p.dkg.c.NewNodes)
 	var oldN = len(p.dkg.c.OldNodes)
 	// we keep the phase in sync with the dkg phase
-	state := func() Phase {
+	phase := func() Phase {
 		return p.dkg.state
 	}
 	// each of the following function returns true or false depending on whether
 	// the protocol should be aborted or not.
 	transition := func(exp Phase, fn func() bool) func() bool {
 		return func() bool {
-			if state() != exp {
+			if phase() != exp {
 				return true
 			}
 			return fn()

--- a/share/dkg/protocol.go
+++ b/share/dkg/protocol.go
@@ -157,33 +157,22 @@ func (p *Protocol) startFast() {
 	var newN = len(p.dkg.c.NewNodes)
 	var oldN = len(p.dkg.c.OldNodes)
 	var phase Phase
-	sendResponseFn := func() bool {
-		if phase != DealPhase {
-			return true
+	// each of the following function returns true or false depending on whether
+	// the protocol should be aborted or not.
+	transition := func(exp Phase, fn func() bool) func() bool {
+		return func() bool {
+			if phase != exp {
+				return true
+			}
+			phase = phase.Next()
+			return fn()
 		}
-		phase = ResponsePhase
-		if !p.sendResponses(deals.ToDeals()) {
-			return false
-		}
-		return true
 	}
-	sendJustifFn := func() bool {
-		if phase != ResponsePhase {
-			return true
-		}
-		phase = JustifPhase
-		if !p.sendJustifications(resps.ToResponses()) {
-			return false
-		}
-		return true
-	}
-	finishFn := func() {
-		if phase != JustifPhase {
-			// although it should never happen twice but never too sure
-			return
-		}
-		p.finish(justifs.ToJustifications())
-	}
+	toResp := transition(DealPhase, func() bool { return p.sendResponses(deals.ToDeals()) })
+	toJust := transition(ResponsePhase, func() bool { return p.sendJustifications(resps.ToResponses()) })
+	// always return false when we are in the finish phase - we quit the
+	// protocol.
+	toFinish := transition(JustifPhase, func() bool { p.finish(justifs.ToJustifications()); return false })
 	for {
 		select {
 		case newPhase := <-p.phaser.NextPhase():
@@ -194,15 +183,16 @@ func (p *Protocol) startFast() {
 					return
 				}
 			case ResponsePhase:
-				if !sendResponseFn() {
+				if !toResp() {
 					return
 				}
 			case JustifPhase:
-				if !sendJustifFn() {
+				if !toJust() {
 					return
 				}
 			case FinishPhase:
-				finishFn()
+				// whatever happens here, if phaser says it's finished we finish
+				toFinish()
 				return
 			}
 		case newDeal := <-p.board.IncomingDeal():
@@ -210,7 +200,7 @@ func (p *Protocol) startFast() {
 				deals.Push(&newDeal)
 			}
 			if deals.Len() == oldN {
-				if !sendResponseFn() {
+				if !toResp() {
 					return
 				}
 			}
@@ -219,7 +209,7 @@ func (p *Protocol) startFast() {
 				resps.Push(&newResp)
 			}
 			if resps.Len() == newN {
-				if !sendJustifFn() {
+				if !toJust() {
 					return
 				}
 			}
@@ -228,8 +218,13 @@ func (p *Protocol) startFast() {
 				justifs.Push(&newJust)
 			}
 			if justifs.Len() == oldN {
-				finishFn()
-				return
+				// we finish only if it's time to do so, maybe we received
+				// justifications but are not in the right phase yet since it
+				// may not be the right time or haven't received enough msg from
+				// previous phase
+				if !toFinish() {
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
During resharing nodes have seen the following log
```
drand: error from dkg: node can only process justifications after processing responses
```
This should not happen because drand is using the `protocol.go` that must ensure the correct transition. I am not yet sure how that happened during drand
This PR brings some resilient logic, code cleaning and more info from logs. 