### PR TITLE
Hash() returns different values, leading to invalid signature verification

### DIFF
--- a/share/dkg/structs.go
+++ b/share/dkg/structs.go
@@ -113,7 +113,7 @@ type DealBundle struct {
 // Hash hashes the index, public coefficients and deals
 func (d *DealBundle) Hash() []byte {
 	// first order the deals in a  stable order
-	sort.Slice(d.Deals, func(i, j int) bool {
+	sort.SliceStable(d.Deals, func(i, j int) bool {
 		return d.Deals[i].ShareIndex < d.Deals[j].ShareIndex
 	})
 	h := sha256.New()
@@ -163,7 +163,7 @@ type ResponseBundle struct {
 // Hash hashes the share index and responses
 func (r *ResponseBundle) Hash() []byte {
 	// first order the response slice in a canonical order
-	sort.Slice(r.Responses, func(i, j int) bool {
+	sort.SliceStable(r.Responses, func(i, j int) bool {
 		return r.Responses[i].DealerIndex < r.Responses[j].DealerIndex
 	})
 	h := sha256.New()
@@ -218,7 +218,7 @@ type Justification struct {
 
 func (j *JustificationBundle) Hash() []byte {
 	// sort them in a canonical order
-	sort.Slice(j.Justifications, func(a, b int) bool {
+	sort.SliceStable(j.Justifications, func(a, b int) bool {
 		return j.Justifications[a].ShareIndex < j.Justifications[b].ShareIndex
 	})
 	h := sha256.New()


### PR DESCRIPTION
This is a very subtle bug which I think originates in the use of `sort.Slice`. 
This is a bug that only appeared systematically with large number of nodes where I guess the logic of sorting is buggy. The initial reason for me to suspect this place was because experiments on drand with a number of nodes >=64 systematically failed. This is because the `Hash()` on `DealBundle` and `ResponseBundle` was returning different values hence the signature was not verified correctly.
 
The short version is that using [`sort.Slice`](https://github.com/drand/kyber/blob/fix/order-trial/share/dkg/structs.go#L157) instead of `sort.SliceStable` gives back a _non sorted_ array sometimes ! We order as in the following:
```go
sort.Slice(d.Deals[:], func(i, j int) bool {
    return d.Deals[i].ShareIndex < d.Deals[j].ShareIndex
})
```
Here is an extract of my findings below that try to justify this claim when sorting the deals from a dealer (needed to get a consistent hash):
```
sort.Slice version Deals:
-[0] Share: 1 -> 20807e -[1] Share: 2 -> 13a8c1 -[2] Share: 3 -> 2e5160 -[3] Share: 4 -> 2f42db -[4
] Share: 5 -> f8be21    -[5] Share: 6 -> e3ba8a -[6] Share: 7 -> 9e19c1 -[7] Share: 8 -> fd5060 -[8
] Share: 9 -> 6b7437    -[9] Share: 10 -> 9e628d        -[10] Share: 11 -> cd33a4       -[11] Share
: 12 -> c9c45c  -[12] Share: 13 -> da07a5       -[13] Share: 14 -> 0f5e41       -[14] Share: 15 ->
708696  -[15] Share: 0 -> d24d74        -[16] Share: 16 -> e2210e       -[17] Share: 17 -> c58035 -
[18] Share: 18 -> 8502d4        -[19] Share: 20 -> 44176c       -[20] Share: 21 -> eb1dfd       -[2
1] Share: 22 -> 9f5193  -[22] Share: 23 -> f52b8a       -[23] Share: 24 -> 417fca       -[24] Share
: 25 -> 1b0863  -[25] Share: 26 -> 650bb6       -[26] Share: 27 -> d60015       -[27] Share: 28 ->
4e46d8  -[28] Share: 29 -> 2f9d0a       -[29] Share: 30 -> 2278ea       -[30] Share: 31 -> c2cd27 -
[31] Share: 32 -> 4b212f        -[32] Share: 33 -> 224aca       -[33] Share: 34 -> 450497       -[3
4] Share: 35 -> 504871  -[35] Share: 36 -> f85c0f       -[36] Share: 37 -> a928a8       -[37] Share
: 38 -> 333218  -[38] Share: 39 -> 082134       -[39] Share: 40 -> 611a4d       -[40] Share: 41 ->
8bf950  -[41] Share: 42 -> 67a623       -[42] Share: 43 -> c310be       -[43] Share: 44 -> 2e5799 -
[44] Share: 45 -> fa04d4        -[45] Share: 46 -> e43821       -[46] Share: 47 -> 5e4e0c       -[4
7] Share: 48 -> 7d9955  -[48] Share: 49 -> 6bde89       -[49] Share: 50 -> e64f2a       -[50] Share
: 51 -> 6c5f28  -[51] Share: 52 -> 6b7550       -[52] Share: 53 -> 69d3c3       -[53] Share: 54 ->
5458dc  -[54] Share: 55 -> c80007       -[55] Share: 56 -> 12999f       -[56] Share: 57 -> 7713ed -
[57] Share: 58 -> 26f210        -[58] Share: 59 -> cf5007       -[59] Share: 60 -> 33b693       -[6
0] Share: 61 -> c88942  -[61] Share: 62 -> a618ea       -[62] Share: 63 -> bca617


 -----------------
ORIGINAL:
-[0] Share: 0 -> d24d74 -[1] Share: 1 -> 20807e -[2] Share: 2 -> 13a8c1 -[3] Share: 3 -> 2e5160 -[4
] Share: 4 -> 2f42db    -[5] Share: 5 -> f8be21 -[6] Share: 6 -> e3ba8a -[7] Share: 7 -> 9e19c1 -[8
] Share: 8 -> fd5060    -[9] Share: 9 -> 6b7437 -[10] Share: 10 -> 9e628d       -[11] Share: 11 ->
cd33a4  -[12] Share: 12 -> c9c45c       -[13] Share: 13 -> da07a5       -[14] Share: 14 -> 0f5e41 -
[15] Share: 15 -> 708696        -[16] Share: 16 -> e2210e       -[17] Share: 17 -> c58035       -[1
8] Share: 18 -> 8502d4  -[19] Share: 20 -> 44176c       -[20] Share: 21 -> eb1dfd       -[21] Share
: 22 -> 9f5193  -[22] Share: 23 -> f52b8a       -[23] Share: 24 -> 417fca       -[24] Share: 25 ->
1b0863  -[25] Share: 26 -> 650bb6       -[26] Share: 27 -> d60015       -[27] Share: 28 -> 4e46d8 -
[28] Share: 29 -> 2f9d0a        -[29] Share: 30 -> 2278ea       -[30] Share: 31 -> c2cd27       -[3
1] Share: 32 -> 4b212f  -[32] Share: 33 -> 224aca       -[33] Share: 34 -> 450497       -[34] Share
: 35 -> 504871  -[35] Share: 36 -> f85c0f       -[36] Share: 37 -> a928a8       -[37] Share: 38 ->
333218  -[38] Share: 39 -> 082134       -[39] Share: 40 -> 611a4d       -[40] Share: 41 -> 8bf950 -
[41] Share: 42 -> 67a623        -[42] Share: 43 -> c310be       -[43] Share: 44 -> 2e5799       -[4
4] Share: 45 -> fa04d4  -[45] Share: 46 -> e43821       -[46] Share: 47 -> 5e4e0c       -[47] Share
: 48 -> 7d9955  -[48] Share: 49 -> 6bde89       -[49] Share: 50 -> e64f2a       -[50] Share: 51 ->
6c5f28  -[51] Share: 52 -> 6b7550       -[52] Share: 53 -> 69d3c3       -[53] Share: 54 -> 5458dc -
[54] Share: 55 -> c80007        -[55] Share: 56 -> 12999f       -[56] Share: 57 -> 7713ed       -[5
7] Share: 58 -> 26f210  -[58] Share: 59 -> cf5007       -[59] Share: 60 -> 33b693       -[60] Share
: 61 -> c88942  -[61] Share: 62 -> a618ea       -[62] Share: 63 -> bca617

 -------------------
 DIFFERENCE: d1[0].ShareIndex = 1 != d2[0].ShareIndex = 0
```
You can see in the first extract that `-[15] Share: 0 -> d24d74 ` , i.e. the share for share holder 0 is located _after_ (15 indices after!) the share for share holder 1 (located at the beginning of the array) -> this is contrary to the sorting function given in argument!. When you look at the original, the slice copied before `sort` is called, (which is already sorted because the dealer created it in order already), the share of share holder 0 is really at index 0, as it should.

To be honest, I am not completely sure of the reason why but it feels like a bug in `sort.Slice` or at the very least in the expectation I have of this function.

`sort.SliceStable` systematically works, as expected.

If you wanna try it out yourself, go to the branch `fix/order-trial` , go to `cd share/dkg` and run `go test -v -run TestDKGFullFast`.