### PR TITLE
Fix IBE hash endianness

### DIFF
--- a/group/mod/int.go
+++ b/group/mod/int.go
@@ -442,7 +442,7 @@ func (i *Int) Hash(h kyber.HashFactory, input io.Reader) (kyber.Scalar, error) {
 		hash := h.Hash()
 		_, _ = hash.Write(buffer)
 		copy(buffer, hash.Sum(nil))
-		if i.BO == LittleEndian {
+		if i.BO == BigEndian {
 			buffer[0] = buffer[0] >> toMask
 		} else {
 			buffer[len(buffer)-1] = buffer[len(buffer)-1] >> toMask


### PR DESCRIPTION
Big endian means the MSB is stored in the smallest array index.
![image](https://user-images.githubusercontent.com/10077203/182827041-443478c7-b18e-4e17-ab45-59caa4bf21c2.png)
