### PR TITLE
IBE unit test for tlock typescript compat

### DIFF
--- a/encrypt/ibe/ibe.go
+++ b/encrypt/ibe/ibe.go
@@ -142,9 +142,7 @@ func h3(s pairing.Suite, sigma, msg []byte) (kyber.Scalar, error) {
 		panic("scalar can't be created from hash")
 	}
 
-	h3Reader := bytes.NewReader(h3.Sum(nil))
-
-	return hashable.Hash(s, h3Reader)
+	return hashable.Hash(s, bytes.NewReader(h3.Sum(nil)))
 }
 
 func h4(s pairing.Suite, sigma []byte, length int) ([]byte, error) {
@@ -156,13 +154,8 @@ func h4(s pairing.Suite, sigma []byte, length int) ([]byte, error) {
 	if _, err := h4.Write(sigma); err != nil {
 		return nil, fmt.Errorf("err writing sigma to h4: %v", err)
 	}
+	h4sigma := h4.Sum(nil)[:length]
 
-	h4Reader := bytes.NewReader(h4.Sum(nil))
-	h4sigma := make([]byte, length)
-
-	if _, err := h4Reader.Read(h4sigma); err != nil {
-		return nil, fmt.Errorf("err reading from h4: %v", err)
-	}
 	return h4sigma, nil
 }
 

--- a/encrypt/ibe/ibe_test.go
+++ b/encrypt/ibe/ibe_test.go
@@ -1,6 +1,7 @@
 package ibe
 
 import (
+	"encoding/hex"
 	"strings"
 	"testing"
 
@@ -93,4 +94,47 @@ func TestInvalidWFailsDecryptionBecauseOfLength(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "XorSigma is of invalid length")
+}
+
+func TestBackwardsInteropWithTypescript(t *testing.T) {
+	suite, _, _, _ := newSetting()
+
+	hexToPoint := func(p kyber.Point, input string) (kyber.Point, error) {
+		h, err := hex.DecodeString(input)
+		if err != nil {
+			return nil, err
+		}
+
+		err = p.UnmarshalBinary(h)
+		return p, err
+	}
+
+	// taken from the testnet round 1
+	beacon, err := hexToPoint(
+		suite.G2().Point(),
+		"86ecea71376e78abd19aaf0ad52f462a6483626563b1023bd04815a7b953da888c74f5bf6ee672a5688603ab310026230522898f33f23a7de363c66f90ffd49ec77ebf7f6c1478a9ecd6e714b4d532ab43d044da0a16fed13b4791d7fc999e2b",
+	)
+	require.NoError(t, err)
+
+	// generated using the typescript client at commit `53b562addf179461630b0cc80c0e4ac3436ee4ff`
+	U, err := hexToPoint(
+		suite.G1().Point(),
+		"a5ddec5fa76795d5a28f0869e6a620248c94c112beb8135b11d5614a2b6845c5a4128e3dfe4328d7a6e70b2dea3d7f25",
+	)
+	require.NoError(t, err)
+
+	V, err := hex.DecodeString("89f0e6cf2b27371017dddeff43ab2263")
+	require.NoError(t, err)
+
+	W, err := hex.DecodeString("d767e14f5e3e1738a6c50725c4f0d1b6")
+	require.NoError(t, err)
+
+	expectedFileKey, err := hex.DecodeString("deadbeefdeadbeefdeadbeefdeadbeef")
+	require.NoError(t, err)
+
+	ciphertext := Ciphertext{U: U, W: W, V: V}
+
+	result, err := Decrypt(suite, beacon, &ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, expectedFileKey, result)
 }


### PR DESCRIPTION
* generated a few static test vectors from the typescript tlock library to ensure backwards compatibility to any future IBE changes
* refactored out some redundant steps/vars in both h3 and h4