### PR TITLE
use correct threshold in dkg

### DIFF
--- a/share/dkg/dkg.go
+++ b/share/dkg/dkg.go
@@ -1093,7 +1093,7 @@ func findIndex(list []Node, index Index) (kyber.Point, bool) {
 }
 
 func MinimumT(n int) int {
-	return (n + 1) / 2
+	return (n >> 1) + 1
 }
 
 func isIndexIncluded(list []Node, index uint32) bool {


### PR DESCRIPTION
This is fine for drand as we use our own threshold calculation in drand https://github.com/drand/drand/blob/master/key/group.go#L355 but the DKG package should use this as well. n / 2 + 1 is the right number