### PR TITLE
Remove n^2 algorithm from signature/key aggregation

### DIFF
--- a/sign/bdn/bdn.go
+++ b/sign/bdn/bdn.go
@@ -32,23 +32,16 @@ var modulus128 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewI
 // We also use the entire roster so that the coefficient will vary for the same
 // public key used in different roster
 func hashPointToR(pubs []kyber.Point) ([]kyber.Scalar, error) {
-	peers := make([][]byte, len(pubs))
-	for i, pub := range pubs {
-		peer, err := pub.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-
-		peers[i] = peer
-	}
-
 	h, err := blake2s.NewXOF(blake2s.OutputLengthUnknown, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, peer := range peers {
-		_, err := h.Write(peer)
+	for _, pub := range pubs {
+		peer, err := pub.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		_, err = h.Write(peer)
 		if err != nil {
 			return nil, err
 		}

--- a/sign/bdn/bdn.go
+++ b/sign/bdn/bdn.go
@@ -12,6 +12,7 @@ package bdn
 import (
 	"crypto/cipher"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/drand/kyber"
@@ -129,23 +130,28 @@ func (scheme *Scheme) Verify(x kyber.Point, msg, sig []byte) error {
 // AggregateSignatures aggregates the signatures using a coefficient for each
 // one of them where c = H(pk) and H: keyGroup -> R with R = {1, ..., 2^128}
 func (scheme *Scheme) AggregateSignatures(sigs [][]byte, mask *sign.Mask) (kyber.Point, error) {
-	if len(sigs) != mask.CountEnabled() {
-		return nil, errors.New("length of signatures and public keys must match")
-	}
-
-	coefs, err := hashPointToR(mask.Publics())
+	publics := mask.Publics()
+	coefs, err := hashPointToR(publics)
 	if err != nil {
 		return nil, err
 	}
 
 	agg := scheme.sigGroup.Point()
-	for i, buf := range sigs {
-		peerIndex := mask.IndexOfNthEnabled(i)
-		if peerIndex < 0 {
-			// this should never happen as we check the lenths at the beginning
-			// an error here is probably a bug in the mask
-			return nil, errors.New("couldn't find the index")
+	for i := range publics {
+		if enabled, err := mask.GetBit(i); err != nil {
+			// this should never happen because of the loop boundary
+			// an error here is probably a bug in the mask implementation
+			return nil, fmt.Errorf("couldn't find the index %d: %w", i, err)
+		} else if !enabled {
+			continue
 		}
+
+		if len(sigs) == 0 {
+			return nil, errors.New("length of signatures and public keys must match")
+		}
+
+		buf := sigs[0]
+		sigs = sigs[1:]
 
 		sig := scheme.sigGroup.Point()
 		err = sig.UnmarshalBinary(buf)
@@ -153,7 +159,7 @@ func (scheme *Scheme) AggregateSignatures(sigs [][]byte, mask *sign.Mask) (kyber
 			return nil, err
 		}
 
-		sigC := sig.Clone().Mul(coefs[peerIndex], sig)
+		sigC := sig.Clone().Mul(coefs[i], sig)
 		// c+1 because R is in the range [1, 2^128] and not [0, 2^128-1]
 		sigC = sigC.Add(sigC, sig)
 		agg = agg.Add(agg, sigC)
@@ -166,22 +172,23 @@ func (scheme *Scheme) AggregateSignatures(sigs [][]byte, mask *sign.Mask) (kyber
 // AggregateSignatures for signatures) using the hash function
 // H: keyGroup -> R with R = {1, ..., 2^128}.
 func (scheme *Scheme) AggregatePublicKeys(mask *sign.Mask) (kyber.Point, error) {
-	coefs, err := hashPointToR(mask.Publics())
+	publics := mask.Publics()
+	coefs, err := hashPointToR(publics)
 	if err != nil {
 		return nil, err
 	}
 
 	agg := scheme.keyGroup.Point()
-	for i := 0; i < mask.CountEnabled(); i++ {
-		peerIndex := mask.IndexOfNthEnabled(i)
-		if peerIndex < 0 {
+	for i, pub := range publics {
+		if enabled, err := mask.GetBit(i); err != nil {
 			// this should never happen because of the loop boundary
 			// an error here is probably a bug in the mask implementation
-			return nil, errors.New("couldn't find the index")
+			return nil, fmt.Errorf("couldn't find the index %d: %w", i, err)
+		} else if !enabled {
+			continue
 		}
 
-		pub := mask.Publics()[peerIndex]
-		pubC := pub.Clone().Mul(coefs[peerIndex], pub)
+		pubC := pub.Clone().Mul(coefs[i], pub)
 		pubC = pubC.Add(pubC, pub)
 		agg = agg.Add(agg, pubC)
 	}

--- a/sign/bdn/bdn_test.go
+++ b/sign/bdn/bdn_test.go
@@ -1,6 +1,8 @@
 package bdn
 
 import (
+	"encoding"
+	"encoding/hex"
 	"fmt"
 	"testing"
 
@@ -181,6 +183,64 @@ func Benchmark_BDN_AggregateSigs(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		schemeOnG1.AggregateSignatures([][]byte{sig1, sig2}, mask)
 	}
+}
+
+func unmarshalHex[T encoding.BinaryUnmarshaler](t *testing.T, into T, s string) T {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	require.NoError(t, into.UnmarshalBinary(b))
+	return into
+}
+
+// This tests exists to make sure we don't accidentally make breaking changes to signature
+// aggregation by using checking against known aggregated signatures and keys.
+func TestBDNFixtures(t *testing.T) {
+	suite := bn256.NewSuite()
+	schemeOnG1 := NewSchemeOnG1(suite)
+
+	public1 := unmarshalHex(t, suite.G2().Point(), "1a30714035c7a161e286e54c191b8c68345bd8239c74925a26290e8e1ae97ed6657958a17dca12c943fadceb11b824402389ff427179e0f10194da3c1b771c6083797d2b5915ea78123cbdb99ea6389d6d6b67dcb512a2b552c373094ee5693524e3ebb4a176f7efa7285c25c80081d8cb598745978f1a63b886c09a316b1493")
+	private1 := unmarshalHex(t, suite.G2().Scalar(), "49cfe5e9f4532670137184d43c0299f8b635bcacf6b0af7cab262494602d9f38")
+	public2 := unmarshalHex(t, suite.G2().Point(), "603bc61466ec8762ec6de2ba9a80b9d302d08f580d1685ac45a8e404a6ed549719dc0faf94d896a9983ff23423772720e3de5d800bc200de6f7d7e146162d3183b8880c5c0d8b71ca4b3b40f30c12d8cc0679c81a47c239c6aa7e9cc2edab4a927fe865cd413c1c17e3df8f74108e784cd77dd3e161bdaf30019a55826a32a1f")
+	private2 := unmarshalHex(t, suite.G2().Scalar(), "493abea4bb35b74c78ad9245f9d37883aeb6ee91f7fb0d8a8e11abf7aa2be581")
+	public3 := unmarshalHex(t, suite.G2().Point(), "56118769a1f0b6286abacaa32109c1497ab0819c5d21f27317e184b6681c283007aa981cb4760de044946febdd6503ab77a4586bc29c04159e53a6fa5dcb9c0261ccd1cb2e28db5204ca829ac9f6be95f957a626544adc34ba3bc542533b6e2f5cbd0567e343641a61a42b63f26c3625f74b66f6f46d17b3bf1688fae4d455ec")
+	private3 := unmarshalHex(t, suite.G2().Scalar(), "7fb0ebc317e161502208c3c16a4af890dedc3c7b275e8a04e99c0528aa6a19aa")
+
+	sig1Exp, err := hex.DecodeString("0913b76987be19f943be23b636cab9a2484507717326bd8bbdcdbbb6b8d5eb9253cfb3597c3fa550ee4972a398813650825a871f8e0b242ae5ddbce1b7c0e2a8")
+	require.NoError(t, err)
+	sig2Exp, err := hex.DecodeString("21195d29b1863bca1559e24375211d1411d8a28a8f4c772870b07f4ccda2fd5e337c1315c210475c683e3aa8b87d3aed3f7255b3087daa30d1e1432dd61d7484")
+	require.NoError(t, err)
+	sig3Exp, err := hex.DecodeString("3c1ac80345c1733630dbdc8106925c867544b521c259f9fa9678d477e6e5d3d212b09bc0d95137c3dbc0af2241415156c56e757d5577a609293584d045593195")
+	require.NoError(t, err)
+
+	aggSigExp := unmarshalHex(t, suite.G1().Point(), "520875e6667e0acf489e458c6c2233d09af81afa3b2045e0ec2435cfc582ba2c44af281d688efcf991d20975ce32c9933a09f8c4b38c18ef4b4510d8fa0f09d7")
+	aggKeyExp := unmarshalHex(t, suite.G2().Point(), "394d47291878a81fefb17708c57cf8078b24c46bf4554b3012732acd15395dbf09f13a65e068de766f5449d1de130f09bf09dc35a67f7f822f2a187230e155891d40db3c51afa5b3e05a039c50d04ff9c788718a2887e34644a55a14a2a2679226a3315c281e03367a4d797db819625e0c662d35e45e0e9e7604c104179ae8a7")
+
+	msg := []byte("Hello many times Boneh-Lynn-Shacham")
+	sig1, err := schemeOnG1.Sign(private1, msg)
+	require.Nil(t, err)
+	require.Equal(t, sig1Exp, sig1)
+
+	sig2, err := schemeOnG1.Sign(private2, msg)
+	require.Nil(t, err)
+	require.Equal(t, sig2Exp, sig2)
+
+	sig3, err := schemeOnG1.Sign(private3, msg)
+	require.Nil(t, err)
+	require.Equal(t, sig3Exp, sig3)
+
+	mask, _ := sign.NewMask(suite, []kyber.Point{public1, public2, public3}, nil)
+	mask.SetBit(0, true)
+	mask.SetBit(1, false)
+	mask.SetBit(2, true)
+
+	aggSig, err := schemeOnG1.AggregateSignatures([][]byte{sig1, sig2, sig3}, mask)
+	require.NoError(t, err)
+	require.True(t, aggSigExp.Equal(aggSig))
+
+	aggKey, err := schemeOnG1.AggregatePublicKeys(mask)
+	require.NoError(t, err)
+	require.True(t, aggKeyExp.Equal(aggKey))
 }
 
 func TestBDNDeprecatedAPIs(t *testing.T) {

--- a/sign/mask.go
+++ b/sign/mask.go
@@ -59,6 +59,17 @@ func (m *Mask) SetMask(mask []byte) error {
 	return nil
 }
 
+// GetBit returns true if the given bit is set.
+func (m *Mask) GetBit(i int) (bool, error) {
+	if i >= len(m.publics) || i < 0 {
+		return false, errors.New("index out of range")
+	}
+
+	byteIndex := i / 8
+	mask := byte(1) << uint(i&7)
+	return m.mask[byteIndex]&mask != 0, nil
+}
+
 // SetBit turns on or off the bit at the given index.
 func (m *Mask) SetBit(i int, enable bool) error {
 	if i >= len(m.publics) || i < 0 {

--- a/sign/mask.go
+++ b/sign/mask.go
@@ -66,8 +66,8 @@ func (m *Mask) GetBit(i int) (bool, error) {
 	}
 
 	byteIndex := i / 8
-	mask := byte(1) << uint(i&7)
-	return m.mask[byteIndex]&mask != 0, nil
+	bitIndex := byte(1) << uint(i&7)
+	return m.mask[byteIndex]&bitIndex != 0, nil
 }
 
 // SetBit turns on or off the bit at the given index.

--- a/sign/mask_test.go
+++ b/sign/mask_test.go
@@ -45,19 +45,55 @@ func TestMask_CreateMask(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMask_SetBit(t *testing.T) {
+func TestMask_SetGetBit(t *testing.T) {
 	mask, err := NewMask(suite, publics, publics[2])
 	require.NoError(t, err)
+
+	// Make sure the mask is initially as we'd expect.
+
+	bit, err := mask.GetBit(1)
+	require.NoError(t, err)
+	require.False(t, bit)
+
+	bit, err = mask.GetBit(2)
+	require.NoError(t, err)
+	require.True(t, bit)
+
+	// Set bit 1
 
 	err = mask.SetBit(1, true)
 	require.NoError(t, err)
 	require.Equal(t, uint8(0x6), mask.Mask()[0])
 	require.Equal(t, 2, len(mask.Participants()))
 
+	bit, err = mask.GetBit(1)
+	require.NoError(t, err)
+	require.True(t, bit)
+
+	// Unset bit 2
+
 	err = mask.SetBit(2, false)
 	require.NoError(t, err)
 	require.Equal(t, uint8(0x2), mask.Mask()[0])
 	require.Equal(t, 1, len(mask.Participants()))
+
+	bit, err = mask.GetBit(2)
+	require.NoError(t, err)
+	require.False(t, bit)
+
+	// Unset bit 10 (using byte 2 now)
+
+	err = mask.SetBit(10, false)
+	require.NoError(t, err)
+	require.Equal(t, uint8(0x2), mask.Mask()[0])
+	require.Equal(t, uint8(0x4), mask.Mask()[1])
+	require.Equal(t, 2, len(mask.Participants()))
+
+	bit, err = mask.GetBit(10)
+	require.NoError(t, err)
+	require.True(t, bit)
+
+	// And make sure the range limit works.
 
 	err = mask.SetBit(-1, true)
 	require.Error(t, err)


### PR DESCRIPTION
`CountEnabled` and `IndexOfNthEnabled` are both `O(n)` in the size of the mask, making this loop `n^2`. The BLS operations still tend to be the slow part, but the `n^2` factor will start to show up with thousands of keys.